### PR TITLE
Redesign TakeTurn page with area-based consultorio selection

### DIFF
--- a/src/styles/TakeTurn.css
+++ b/src/styles/TakeTurn.css
@@ -106,6 +106,28 @@
   color: var(--text-secondary, #6b7280);
 }
 
+.back-button {
+  background: rgba(108, 117, 125, 0.08);
+  color: var(--text-secondary, #4a5568);
+  border: 2px solid var(--border-light, #e2e8f0);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.back-button:hover {
+  background: var(--bg-card, #edf2f7);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(108, 117, 125, 0.15);
+}
+
 /* Main Button Container */
 .main-button-container {
   display: flex;
@@ -630,5 +652,388 @@
   .submit-button {
     padding: 12px 24px;
     font-size: 14px;
+  }
+}
+
+/* Nueva interfaz de áreas expandidas */
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  gap: 20px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--border-color, #e9ecef);
+  border-top: 4px solid var(--primary-medical, #2f97d1);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.loading-container p {
+  color: var(--text-secondary, #6b7280);
+  font-size: 16px;
+  font-weight: 500;
+  margin: 0;
+}
+
+/* Confirmación de consultorio seleccionado */
+.confirmation-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 20px 0;
+}
+
+.selected-consultorio-card {
+  background: var(--bg-card, #ffffff);
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--border-color, #e9ecef);
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+}
+
+.consultorio-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.consultorio-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--primary-medical, #2f97d1), #1d6fa5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 28px;
+  box-shadow: 0 8px 20px rgba(47, 151, 209, 0.3);
+}
+
+.consultorio-info h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--text-primary, #2c3e50);
+  letter-spacing: -0.3px;
+}
+
+.consultorio-info p {
+  margin: 4px 0 0 0;
+  font-size: 16px;
+  color: var(--text-secondary, #6b7280);
+  font-weight: 500;
+}
+
+.confirmation-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.confirm-button {
+  background: linear-gradient(135deg, var(--success-color, #10b981), #059669);
+  color: white;
+  border: none;
+  padding: 16px 32px;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 6px 20px rgba(16, 185, 129, 0.25);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: relative;
+  overflow: hidden;
+}
+
+.confirm-button::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent);
+  transform: translateX(-100%);
+  transition: transform 0.45s ease;
+  border-radius: inherit;
+}
+
+.confirm-button:hover:not(:disabled)::before {
+  transform: translateX(100%);
+}
+
+.confirm-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 28px rgba(16, 185, 129, 0.35);
+}
+
+.confirm-button:disabled {
+  background: linear-gradient(135deg, #cbd5e1, #94a3b8);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top: 2px solid white;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+/* Vista principal de áreas */
+.areas-container {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  background: var(--bg-card, #ffffff);
+  border-radius: 16px;
+  border: 1px solid var(--border-color, #e9ecef);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.06));
+}
+
+.empty-state svg {
+  font-size: 48px;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 16px;
+}
+
+.empty-state h3 {
+  margin: 0 0 8px 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary, #2c3e50);
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--text-secondary, #6b7280);
+  font-size: 14px;
+}
+
+.areas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 24px;
+}
+
+.area-card {
+  background: var(--bg-card, #ffffff);
+  border-radius: 16px;
+  border: 1px solid var(--border-color, #e9ecef);
+  box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.06));
+  overflow: hidden;
+  transition: all 0.25s ease;
+}
+
+.area-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.1));
+}
+
+.area-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-color, #e9ecef);
+}
+
+.area-header-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.area-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 18px;
+}
+
+.area-info h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+}
+
+.area-info p {
+  margin: 2px 0 0 0;
+  font-size: 14px;
+  color: var(--text-muted, #94a3b8);
+  font-weight: 500;
+}
+
+.area-content {
+  padding: 20px 24px;
+}
+
+.no-consultorios {
+  text-align: center;
+  padding: 20px;
+  color: var(--text-muted, #94a3b8);
+}
+
+.no-consultorios svg {
+  font-size: 32px;
+  margin-bottom: 8px;
+  opacity: 0.5;
+}
+
+.no-consultorios p {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.consultorios-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.consultorio-button {
+  width: 100%;
+  background: var(--bg-main, #f8fafc);
+  border: 1px solid var(--border-color, #e9ecef);
+  border-radius: 8px;
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  overflow: hidden;
+}
+
+.consultorio-button:hover {
+  background: var(--bg-card, #ffffff);
+  border-color: var(--primary-medical, #2f97d1);
+  box-shadow: 0 2px 8px rgba(47, 151, 209, 0.15);
+  transform: translateY(-1px);
+}
+
+.consultorio-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  width: 100%;
+}
+
+.consultorio-content span:first-of-type {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text-primary, #2c3e50);
+  font-size: 14px;
+}
+
+.status-badge {
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.status-badge.success {
+  background: rgba(16, 185, 129, 0.1);
+  color: #059669;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.info-section {
+  margin-top: 32px;
+}
+
+/* Responsive para nueva interfaz */
+@media (max-width: 768px) {
+  .areas-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .selected-consultorio-card {
+    padding: 24px;
+    margin: 0 16px;
+  }
+  
+  .consultorio-header {
+    margin-bottom: 24px;
+  }
+  
+  .consultorio-icon {
+    width: 56px;
+    height: 56px;
+    font-size: 24px;
+  }
+  
+  .consultorio-info h2 {
+    font-size: 20px;
+  }
+  
+  .confirm-button {
+    padding: 14px 24px;
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .areas-grid {
+    gap: 16px;
+  }
+  
+  .area-card {
+    border-radius: 12px;
+  }
+  
+  .area-header {
+    padding: 16px 20px;
+  }
+  
+  .area-content {
+    padding: 16px 20px;
+  }
+  
+  .area-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+  
+  .area-info h3 {
+    font-size: 16px;
+  }
+  
+  .consultorio-content {
+    padding: 10px 12px;
+  }
+  
+  .selected-consultorio-card {
+    padding: 20px;
+    margin: 0 12px;
   }
 }


### PR DESCRIPTION
Refactors the TakeTurn page to allow users to select consultorios grouped by medical area, replacing the previous form-based flow. Adds area and consultorio cards, icon mapping, and confirmation step for turn generation. Updates styles for new UI, including responsive layouts and improved feedback for loading and errors.